### PR TITLE
Sprint 6: HistoryManager - свой LinkedHashMap, целостность данных TaskManager, тесты

### DIFF
--- a/.github/workflows/api-tests.yml
+++ b/.github/workflows/api-tests.yml
@@ -1,0 +1,8 @@
+name: Java Tests
+
+on:
+  pull_request:
+
+jobs:
+  build:
+    uses: yandex-praktikum/java-kanban/.github/workflows/api-tests.yml@ci

--- a/src/HistoryManager.java
+++ b/src/HistoryManager.java
@@ -6,4 +6,6 @@ public interface HistoryManager {
     void addTaskToHistory(Task task);
 
     List<Task> getHistory();
+
+    void remove(int id);
 }

--- a/src/HistoryNode.java
+++ b/src/HistoryNode.java
@@ -1,0 +1,35 @@
+import tasks.Task;
+
+public class HistoryNode {
+    private Task task;
+    private HistoryNode previous;
+    private HistoryNode next;
+
+    public HistoryNode(Task task) {
+        this.task = task;
+    }
+
+    public Task getTask() {
+        return task;
+    }
+
+    public void setTask(Task task) {
+        this.task = task;
+    }
+
+    public HistoryNode getPrevious() {
+        return previous;
+    }
+
+    public void setPrevious(HistoryNode previous) {
+        this.previous = previous;
+    }
+
+    public HistoryNode getNext() {
+        return next;
+    }
+
+    public void setNext(HistoryNode next) {
+        this.next = next;
+    }
+}

--- a/src/InMemoryTaskManager.java
+++ b/src/InMemoryTaskManager.java
@@ -45,23 +45,35 @@ public class InMemoryTaskManager implements TaskManager {
 
     @Override
     public void removeTaskPool() {
+        clearHistoryWhenRemovingPool(taskPool);
         taskPool.clear();
     }
 
     @Override
     public void removeEpicPool() {
+        clearHistoryWhenRemovingPool(epicPool);
+        clearHistoryWhenRemovingPool(subtaskPool);
         epicPool.clear();
         subtaskPool.clear();
     }
 
     @Override
     public void removeSubtaskPool() {
+        clearHistoryWhenRemovingPool(subtaskPool);
         subtaskPool.clear();
         //Пересмотр статуса эпиков согласно логике программы
         for (Integer id : epicPool.keySet()) {
             Epic epic = epicPool.get(id);
             epic.getSubTasksIds().clear();
             epicStatusControl(epic);
+        }
+    }
+
+    private void clearHistoryWhenRemovingPool (Map<Integer, ? extends Task> pool) {
+        if (!pool.isEmpty()) {
+            for (int id : pool.keySet()) {
+                historyManager.remove(id);
+            }
         }
     }
 
@@ -142,6 +154,7 @@ public class InMemoryTaskManager implements TaskManager {
     public void removeTask(int id) {
         Task task = getTask(id, false);
         if (task != null) {
+            historyManager.remove(id);
             TaskTypes taskType = task.getTaskType();
             switch (taskType) {
                 case TASK:

--- a/src/InMemoryTaskManager.java
+++ b/src/InMemoryTaskManager.java
@@ -69,7 +69,7 @@ public class InMemoryTaskManager implements TaskManager {
         }
     }
 
-    private void clearHistoryWhenRemovingPool (Map<Integer, ? extends Task> pool) {
+    private void clearHistoryWhenRemovingPool(Map<Integer, ? extends Task> pool) {
         if (!pool.isEmpty()) {
             for (int id : pool.keySet()) {
                 historyManager.remove(id);
@@ -84,13 +84,13 @@ public class InMemoryTaskManager implements TaskManager {
 
     //Метод вызывается из remove и update, по ТЗ должна собираться история только просмотренных пользователем задач
     private Task getTask(int id, boolean shouldBeAddToHistory) {
-        Task task;
+        Task task = null;
         if (taskPool.containsKey(id)) {
-            task = taskPool.get(id);
+            task = new Task(taskPool.get(id));
         } else if (epicPool.containsKey(id)) {
-            task = epicPool.get(id);
-        } else {
-            task = subtaskPool.getOrDefault(id, null);
+            task = new Epic(epicPool.get(id));
+        } else if (subtaskPool.containsKey(id)) {
+            task = new Subtask(subtaskPool.get(id));
         }
         if (task != null && shouldBeAddToHistory) {
             historyManager.addTaskToHistory(task);
@@ -106,17 +106,17 @@ public class InMemoryTaskManager implements TaskManager {
             TaskTypes taskType = task.getTaskType();
             switch (taskType) {
                 case TASK:
-                    taskPool.put(lastTaskId, task);
+                    taskPool.put(lastTaskId, new Task(task));
                     break;
                 case EPIC:
                     Epic epic = (Epic) task;
-                    epicPool.put(lastTaskId, epic);
+                    epicPool.put(lastTaskId, new Epic(epic));
                     break;
                 case SUBTASK:
                     Subtask subtask = (Subtask) task;
                     int connectedEpicId = subtask.getEpicId();
                     Epic connectedEpic = epicPool.get(connectedEpicId);
-                    subtaskPool.put(lastTaskId, subtask);
+                    subtaskPool.put(lastTaskId, new Subtask(subtask));
                     connectedEpic.addSubTasks(lastTaskId);
                     epicStatusControl(connectedEpic);
                     break;
@@ -134,14 +134,15 @@ public class InMemoryTaskManager implements TaskManager {
             if (oldTask != null && taskType.equals(oldTask.getTaskType())) {
                 switch (taskType) {
                     case TASK:
-                        taskPool.put(taskId, task);
+                        taskPool.put(taskId, new Task(task));
                         break;
                     case EPIC:
-                        epicPool.put(taskId, (Epic) task);
+                        Epic epic = (Epic) task;
+                        epicPool.put(taskId, new Epic(epic));
                         break;
                     case SUBTASK:
                         Subtask subtask = (Subtask) task;
-                        subtaskPool.put(taskId, subtask);
+                        subtaskPool.put(taskId, new Subtask(subtask));
                         int connectedEpicId = subtask.getEpicId();
                         epicStatusControl(epicPool.get(connectedEpicId));
                         break;

--- a/src/Main.java
+++ b/src/Main.java
@@ -37,16 +37,19 @@ public class Main {
 
         printAll(taskManager);
 
-        Epic taskUpdate2 = new Epic("Epic1", "Changed epic and subtasks");
-        taskUpdate2.addSubTasks(taskUpdate1.getId());
-        taskUpdate2.addSubTasks(subtask1.getId());
+        Epic taskUpdate2 = new Epic("Epic1", "Changed epic description");
+        taskUpdate2.addSubTasks(5);
+        taskUpdate2.addSubTasks(6);
+        subtask2 = (Subtask) taskManager.getTask(6);
+        subtask2.setStatus(Status.IN_PROGRESS);
+        taskManager.updateTask(taskUpdate2);
+        taskManager.updateTask(subtask2);
         taskUpdate2.setId(3);
         taskUpdate1.setStatus(Status.DONE);
         taskManager.updateTask(taskUpdate1);
-        taskManager.updateTask(taskUpdate2);
         taskManager.removeTask(2);
         taskManager.getTask(3);
-        taskManager.getTask(6);
+        taskManager.getTask(7);
         printAll(taskManager);
 
         taskManager.removeEpicPool();

--- a/src/tasks/Epic.java
+++ b/src/tasks/Epic.java
@@ -6,11 +6,19 @@ import tasks.enums.TaskTypes;
 import java.util.ArrayList;
 import java.util.List;
 
-public class Epic extends Task{
-     private List<Integer> subTasksIds;
-     public Epic(String name, String description) {
+public class Epic extends Task {
+    private List<Integer> subTasksIds;
+
+    public Epic(String name, String description) {
         super(name, description, Status.NEW);
         subTasksIds = new ArrayList<>();
+        taskType = TaskTypes.EPIC;
+    }
+
+    public Epic(Epic epic) {
+        super(epic.getName(), epic.getDescription(), epic.getStatus());
+        this.id = epic.getId();
+        subTasksIds = epic.getSubTasksIds();
         taskType = TaskTypes.EPIC;
     }
 
@@ -28,5 +36,9 @@ public class Epic extends Task{
     public String toString() {
         return "Epic{id='" + id + ", 'name='" + name + "', description='" + description + "', status=" + status
                 + ", subtasksNumber='" + subTasksIds.size() + "'}";
+    }
+
+    public void setSubTasksIds(List<Integer> subTasksIds) {
+        this.subTasksIds = subTasksIds;
     }
 }

--- a/src/tasks/Subtask.java
+++ b/src/tasks/Subtask.java
@@ -5,9 +5,17 @@ import tasks.enums.TaskTypes;
 
 public class Subtask extends Task {
     private Integer epicId;
+
     public Subtask(String name, String description, Status status, int epicId) {
         super(name, description, status);
         this.epicId = epicId;
+        taskType = TaskTypes.SUBTASK;
+    }
+
+    public Subtask(Subtask subtask) {
+        super(subtask.getName(), subtask.description, subtask.getStatus());
+        this.id = subtask.getId();
+        this.epicId = subtask.getEpicId();
         taskType = TaskTypes.SUBTASK;
     }
 

--- a/src/tasks/Task.java
+++ b/src/tasks/Task.java
@@ -17,6 +17,14 @@ public class Task {
         taskType = TaskTypes.TASK;
     }
 
+    public Task(Task task) {
+        this.id = task.getId();
+        this.name = task.getName();
+        this.description = task.getDescription();
+        this.status = getStatus();
+        taskType = TaskTypes.TASK;
+    }
+
     @Override
     public int hashCode() {
         return id;
@@ -38,7 +46,7 @@ public class Task {
         return id;
     }
 
-    public void setStatus (Status status) {
+    public void setStatus(Status status) {
         this.status = status;
     }
 
@@ -53,5 +61,13 @@ public class Task {
     @Override
     public String toString() {
         return "Task{id='" + id + ", 'name='" + name + "', description='" + description + "', status=" + status + "'}";
+    }
+
+    public String getName() {
+        return name;
+    }
+
+    public String getDescription() {
+        return description;
     }
 }

--- a/src/tasks/Task.java
+++ b/src/tasks/Task.java
@@ -21,7 +21,7 @@ public class Task {
         this.id = task.getId();
         this.name = task.getName();
         this.description = task.getDescription();
-        this.status = getStatus();
+        this.status = task.getStatus();
         taskType = TaskTypes.TASK;
     }
 

--- a/test/InMemoryHistoryManagerTest.java
+++ b/test/InMemoryHistoryManagerTest.java
@@ -1,5 +1,7 @@
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
+import tasks.Epic;
+import tasks.Subtask;
 import tasks.enums.Status;
 import tasks.Task;
 
@@ -38,19 +40,26 @@ class InMemoryHistoryManagerTest {
 
     @Test
     void correctSizeHistoryControl() {
-        for (int i = 1; i < 13; i++) {
+        for (int i = 1; i <= 13; i++) {
             Task newTask = new Task("Name" + i, "Description" + i, Status.NEW);
-            newTask.setId((i + 1));
+            newTask.setId((i));
             historyManager.addTaskToHistory(newTask);
         }
+
+        for (int i = 1; i < 6; i++) {
+            Task newTask = new Task("Name" + i, "Description" + i, Status.NEW);
+            newTask.setId((i));
+            historyManager.addTaskToHistory(newTask);
+        }
+
         List<Task> history = historyManager.getHistory();
-        assertEquals(10, history.size(), "Некорректный размер истории");
-        assertEquals("Task{id='4, 'name='Name3', description='Description3', status=NEW'}",
+        assertEquals(13, history.size(), "Некорректный размер истории");
+        assertEquals("Task{id='6, 'name='Name6', description='Description6', status=NEW'}",
                 history.get(0).toString(), "Некорректный порядок задач в истории");
-        assertEquals("Task{id='9, 'name='Name8', description='Description8', status=NEW'}",
+        assertEquals("Task{id='11, 'name='Name11', description='Description11', status=NEW'}",
                 history.get(5).toString(), "Некорректный порядок задач в истории");
-        assertEquals("Task{id='13, 'name='Name12', description='Description12', status=NEW'}",
-                history.get(9).toString(), "Некорректный порядок задач в истории");
+        assertEquals("Task{id='1, 'name='Name1', description='Description1', status=NEW'}",
+                history.get(8).toString(), "Некорректный порядок задач в истории");
     }
 
     @Test
@@ -63,9 +72,30 @@ class InMemoryHistoryManagerTest {
         taskManager.updateTask(updateTask);
         taskManager.getTask(1);
         List<Task> tasks = taskManager.getHistory();
-        assertEquals("Task{id='1, 'name='Name', description='Description', status=NEW'}",
-                tasks.get(0).toString(), "Первая версия задачи не корректно сохранена");
+        assertEquals(1, tasks.size(), "Некорректный размер истории");
         assertEquals("Task{id='1, 'name='Name', description='Task done', status=DONE'}",
-                tasks.get(1).toString(), "Вторая версия задачи не корректно сохранена");
+                tasks.get(0).toString(), "Вторая версия задачи не корректно сохранена");
+    }
+
+    @Test
+    void historyManagerClearWhenRemoveEpicPool() {
+        TaskManager taskManager = Managers.getDefault();
+        Epic epic1 = new Epic("Epic1", "First epic to complete");
+        Epic epic2 = new Epic("Epic2", "Second epic to complete");
+        Subtask subtask1 = new Subtask("Subtask1", "First Subtask to first epic", Status.NEW, 1);
+        Subtask subtask2 = new Subtask("Subtask2", "Second Subtask to first epic", Status.NEW, 2);
+        taskManager.createTask(epic1);
+        taskManager.createTask(epic2);
+        taskManager.createTask(subtask1);
+        taskManager.createTask(subtask2);
+        taskManager.getTask(1);
+        taskManager.getTask(2);
+        taskManager.getTask(3);
+        taskManager.getTask(4);
+        List<Task> history = taskManager.getHistory();
+        assertEquals(4, history.size(), "Некорректный размер истории");
+        taskManager.removeEpicPool();
+        history = taskManager.getHistory();
+        assertEquals(0, history.size(), "Некорректный размер истории");
     }
 }

--- a/test/InMemoryHistoryManagerTest.java
+++ b/test/InMemoryHistoryManagerTest.java
@@ -2,8 +2,8 @@ import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import tasks.Epic;
 import tasks.Subtask;
-import tasks.enums.Status;
 import tasks.Task;
+import tasks.enums.Status;
 
 import java.util.List;
 
@@ -11,62 +11,53 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 
 class InMemoryHistoryManagerTest {
-
-    HistoryManager historyManager;
-    Task task;
+    TaskManager taskManager;
 
     @BeforeEach
     void beforeEach() {
-        historyManager = Managers.getDefaultHistory();
-        task = new Task("Name", "Description", Status.NEW);
-        task.setId(1);
-        historyManager.addTaskToHistory(task);
+        taskManager = Managers.getDefault();
+        taskManager.createTask(new Task("Name", "Description", Status.NEW));
+        taskManager.getTask(1);
     }
 
     @Test
     void getHistory() {
-        List<Task> tasks = historyManager.getHistory();
+        List<Task> tasks = taskManager.getHistory();
         assertNotNull(tasks, "История не возвращается из HistoryManager");
         assertEquals(1, tasks.size(), "Возвращается некорректный список истории просмотров задач");
     }
 
     @Test
     void addTaskToHistory() {
-        Task task2 = new Task("Name2", "Description2", Status.NEW);
-        historyManager.addTaskToHistory(task2);
-        List<Task> tasks = historyManager.getHistory();
-        assertEquals(2, tasks.size(), "Задача не добавлена");
+        taskManager.createTask(new Task("Name2", "Description2", Status.NEW));
+        assertEquals(1, taskManager.getHistory().size(), "Задача в историю добавляется при создании, а не просмотре");
+        taskManager.getTask(2);
+        assertEquals(2, taskManager.getHistory().size(), "Задача не добавлена в историю после просмотра");
     }
 
     @Test
     void correctSizeHistoryControl() {
         for (int i = 1; i <= 13; i++) {
-            Task newTask = new Task("Name" + i, "Description" + i, Status.NEW);
-            newTask.setId((i));
-            historyManager.addTaskToHistory(newTask);
+            taskManager.createTask(new Task("Name" + i, "Description" + i, Status.NEW));
+            taskManager.getTask(i + 1); //одна задача уже есть создана в BeforeEach
         }
 
-        for (int i = 1; i < 6; i++) {
-            Task newTask = new Task("Name" + i, "Description" + i, Status.NEW);
-            newTask.setId((i));
-            historyManager.addTaskToHistory(newTask);
+        for (int i = 1; i <= 5; i++) {
+            taskManager.getTask(i + 1);
         }
 
-        List<Task> history = historyManager.getHistory();
-        assertEquals(13, history.size(), "Некорректный размер истории");
-        assertEquals("Task{id='6, 'name='Name6', description='Description6', status=NEW'}",
-                history.get(0).toString(), "Некорректный порядок задач в истории");
-        assertEquals("Task{id='11, 'name='Name11', description='Description11', status=NEW'}",
+        List<Task> history = taskManager.getHistory();
+        assertEquals(14, history.size(), "Некорректный размер истории");
+        assertEquals("Task{id='1, 'name='Name', description='Description', status=NEW'}",
+                history.get(0).toString(), "Некорректный порядок задач в истории"); //вызов в BeforeEach
+        assertEquals("Task{id='11, 'name='Name10', description='Description10', status=NEW'}",
                 history.get(5).toString(), "Некорректный порядок задач в истории");
-        assertEquals("Task{id='1, 'name='Name1', description='Description1', status=NEW'}",
-                history.get(8).toString(), "Некорректный порядок задач в истории");
+        assertEquals("Task{id='2, 'name='Name1', description='Description1', status=NEW'}",
+                history.get(9).toString(), "Некорректный порядок задач в истории");
     }
 
     @Test
-    void historyManagerSaveTaskConditions() {
-        TaskManager taskManager = Managers.getDefault();
-        taskManager.createTask(task);
-        taskManager.getTask(1);
+    void historyManagerSaveTaskLastConditions() {
         Task updateTask = new Task("Name", "Task done", Status.DONE);
         updateTask.setId(1);
         taskManager.updateTask(updateTask);
@@ -79,23 +70,22 @@ class InMemoryHistoryManagerTest {
 
     @Test
     void historyManagerClearWhenRemoveEpicPool() {
-        TaskManager taskManager = Managers.getDefault();
         Epic epic1 = new Epic("Epic1", "First epic to complete");
         Epic epic2 = new Epic("Epic2", "Second epic to complete");
-        Subtask subtask1 = new Subtask("Subtask1", "First Subtask to first epic", Status.NEW, 1);
-        Subtask subtask2 = new Subtask("Subtask2", "Second Subtask to first epic", Status.NEW, 2);
+        Subtask subtask1 = new Subtask("Subtask1", "First Subtask to first epic", Status.NEW, 2);
+        Subtask subtask2 = new Subtask("Subtask2", "Second Subtask to first epic", Status.NEW, 3);
         taskManager.createTask(epic1);
         taskManager.createTask(epic2);
         taskManager.createTask(subtask1);
         taskManager.createTask(subtask2);
-        taskManager.getTask(1);
         taskManager.getTask(2);
         taskManager.getTask(3);
         taskManager.getTask(4);
+        taskManager.getTask(5);
         List<Task> history = taskManager.getHistory();
-        assertEquals(4, history.size(), "Некорректный размер истории");
+        assertEquals(5, history.size(), "Некорректный размер истории");
         taskManager.removeEpicPool();
         history = taskManager.getHistory();
-        assertEquals(0, history.size(), "Некорректный размер истории");
+        assertEquals(1, history.size(), "Некорректный размер истории");
     }
 }

--- a/test/InMemoryTaskManagerTest.java
+++ b/test/InMemoryTaskManagerTest.java
@@ -9,7 +9,6 @@ import tasks.Task;
 import java.util.List;
 
 import static org.junit.jupiter.api.Assertions.*;
-import static org.junit.jupiter.api.Assertions.assertEquals;
 
 class InMemoryTaskManagerTest {
     TaskManager taskManager;
@@ -147,5 +146,27 @@ class InMemoryTaskManagerTest {
                 taskManager.getTask(9).toString(), "Изменения проведены некорректно");
         assertEquals(Status.IN_PROGRESS, taskManager.getTask(4).getStatus(), "Статус эпика не изменен");
         assertEquals(Status.DONE, taskManager.getTask(5).getStatus(), "Статус эпика не изменен");
+    }
+
+    @Test
+    void clearingEpicsSubtaskListWhenDeleteSubtask() {
+        taskManager.removeTask(9);
+        Epic epic1 = (Epic) taskManager.getTask(4);
+        Epic epic2 = (Epic) taskManager.getTask(5);
+        assertEquals(3, epic1.getSubTasksIds().size(), "Некорректный размер списка подзадач");
+        assertEquals(0, epic2.getSubTasksIds().size(), "Некорректный размер списка подзадач");
+    }
+
+    @Test
+    void dataInBaseCannotBeChangedWithoutUsingManager() {
+        Task task = new Task("Name", "Description", Status.NEW);
+        taskManager.createTask(task);
+        task.setId(16);
+        Task taskInManager = taskManager.getTask(16);
+        assertNull(taskInManager, "Пользователь изменил данные извне");
+        taskInManager = taskManager.getTask(10);
+        taskInManager.setStatus(Status.DONE);
+        assertEquals("Task{id='10, 'name='Name', description='Description', status=NEW'}",
+                taskManager.getTask(10).toString(), "Пользователь изменил данные через метод getTask");
     }
 }


### PR DESCRIPTION
При реализации своего связанного списка/мапы реализовал изменения внутри уже существующих методов addTaskToHistory, remove, getHistory, не стал писать отдельные методы которые предлагались в подсказке(linkLast, getTasks, removeNode), тк ведь по сути они дела делают тоже что существующие методы.

Целостность данных гарантировал тем, что теперь при создании задачи, в базу записывается копия переданной в качестве аргумента, а при получении задачи пользователю возвращается копия задачи из базы, таким образом у пользователя никогда не будет ссылки на объект хранящийся в самой базе.

Пункт "Удаляемые подзадачи не должны хранить внутри себя старые id." не понял, зачем это делать, ведь по ТЗ не предусмотрено повторное использование id, а при удалении подзадачи ссылки на id этой подзадачи удаляются и из эпиков. Если тут все же надо обнулять id пожалуйста напишите, но и тогда и вопрос почему это касается только подзадач, а не эпиков и задач.